### PR TITLE
Update GitHub repository URL to use https

### DIFF
--- a/BoundedChan.cabal
+++ b/BoundedChan.cabal
@@ -24,4 +24,4 @@ library
 
 source-repository head
   type:     git
-  location: git://github.com/GaloisInc/BoundedChan.git
+  location: https://github.com/GaloisInc/BoundedChan.git


### PR DESCRIPTION
`git://` is no longer supported.